### PR TITLE
Add unit declarator to module and class declarations

### DIFF
--- a/lib/Sprockets.pm
+++ b/lib/Sprockets.pm
@@ -1,4 +1,4 @@
-module Sprockets;
+unit module Sprockets;
 my @extensions = <js html css txt
 	png gif jpg jpeg
 	otf ttf>;

--- a/lib/Sprockets/File.pm
+++ b/lib/Sprockets/File.pm
@@ -1,4 +1,4 @@
-class Sprockets::File;
+unit class Sprockets::File;
 use Sprockets::Filter;
 
 has Str $.realpath; # file's realpath

--- a/lib/Sprockets/Filter.pm
+++ b/lib/Sprockets/Filter.pm
@@ -1,4 +1,4 @@
-module Sprockets::Filters;
+unit module Sprockets::Filters;
 
 sub temporary-filename(Str $prefix) {
   my @range = 

--- a/lib/Sprockets/Locator.pm
+++ b/lib/Sprockets/Locator.pm
@@ -1,6 +1,6 @@
 use Sprockets;
 use Sprockets::File;
-class Sprockets::Locator;
+unit class Sprockets::Locator;
 has %.paths;
 
 method find-file($name, $ext) {

--- a/lib/Sprockets/Pipeline.pm
+++ b/lib/Sprockets/Pipeline.pm
@@ -1,5 +1,5 @@
 use Sprockets::Locator;
-class Sprockets::Pipeline;
+unit class Sprockets::Pipeline;
 
 # Filters part...
 # To be moved out, I guess

--- a/t/lib/testhelper.pm
+++ b/t/lib/testhelper.pm
@@ -1,6 +1,6 @@
 use lib './lib/';
 use Sprockets::Locator;
-module lib::testhelper;
+unit module lib::testhelper;
 
 my $locator = Sprockets::Locator.new(paths => {
 	template => {


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.